### PR TITLE
fix(error handling): Corrected error handling in rpc-server

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -155,6 +155,8 @@ errors.wrapProtocolError = function(err) {
   case ErrorCode.MethodNotFound: ErrorType = errors.MethodNotFoundError; break;
   case ErrorCode.InvalidParams: ErrorType = errors.InvalidParamsError; break;
   case ErrorCode.InternalError: ErrorType = errors.InternalError; break;
+  default:
+    return err;
   }
 
   var result = new ErrorType();

--- a/lib/rpc-server.js
+++ b/lib/rpc-server.js
@@ -145,10 +145,12 @@ RpcServer.prototype._respond = function(replyTo, correlationId, response) {
 function formatError(error) {
   error = error || {};
 
-  var errorData = {};
+  var errorData = new Error();
   errorData.code = error.hasOwnProperty('code') ? error.code : ErrorCode.InternalError;
   errorData.message = error.hasOwnProperty('message') ? error.message : 'Internal error';
-  errorData.data = error.hasOwnProperty('data') ? error.data : error;
+  if (error.hasOwnProperty('data')) {
+    errorData.data =  error.data;
+  }
   return { error: errorData };
 }
 
@@ -199,7 +201,7 @@ RpcServer.prototype._processMessage = function(receiver, message) {
         return requestData[0].method.apply(null, requestData[1]);
       })
       .then(function(response) { return formatResponse(response); })
-      .error(function(err) { return formatError(err); })
+      .catch(function(err) { return formatError(err); })
       .then(function(response) {
         result.push(response);
         return result;
@@ -233,7 +235,7 @@ RpcServer.prototype._processMessage = function(receiver, message) {
 
   return response
     .then(function(response) { return formatResponse(response); })
-    .error(function(err) {
+    .catch(function(err) {
       receiver.accept(message);
       return formatError(err);
     })


### PR DESCRIPTION
Bluebird Promise.error wasn't always catching thrown error or rejected promise. hence changed it to generic catch. Also returning Error object instead of json object. Need to check if error type also can be propagated